### PR TITLE
Add automated testing and basic error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.6"
+install:
+  - pip install -r requirements.txt
+script:
+  - "pytest"

--- a/PyBall.py
+++ b/PyBall.py
@@ -5,25 +5,33 @@ from models.people import People
 from models.game_types import GameType
 from models.venue import Venue
 
+from error_parser import ErrorParser
+
 
 class PyBall:
     def __init__(self):
         self.r = requests
 
+    def _get(self, url):
+        results = self.r.get(url).json()
+        if 'messageNumber' in results:
+            ErrorParser.parse_error(results)
+        return results
+
     def get_player(self, player_id):
         url = "{0}/people/{1}".format(BASE_URL, player_id)
-        results = self.r.get(url).json()
+        results = self._get(url)
         return People(**results['people'][0])
 
     def get_game_types(self):
         game_types = []
         url = "{0}/gameTypes".format(BASE_URL)
-        results = self.r.get(url).json()
+        results = self._get(url)
         for game_type in results:
             game_types.append(GameType(**game_type))
         return game_types
 
     def get_venue(self, venue_id):
         url = "{0}/venues/{1}".format(BASE_URL, venue_id)
-        results = self.r.get(url).json()
+        results = self._get(url)
         return Venue(**results['venues'][0])

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,7 @@
 ## PyBall - A MLB.com Stats API Python Client
 
+[![Build Status](https://travis-ci.org/a-hacker/PyBall.svg?branch=master)](https://travis-ci.org/a-hacker/PyBall)
+
 
 ```python
 from PyBall import PyBall

--- a/error_parser.py
+++ b/error_parser.py
@@ -1,0 +1,15 @@
+from exceptions import *
+
+
+class ErrorParser:
+
+    @staticmethod
+    def parse_error(err_json):
+        err_code = err_json['messageNumber']
+        err_message = err_json['message']
+        if err_code == 10:
+            raise InvalidIdError(err_message)
+        elif err_code == 11:
+            raise BadRequestError(err_message)
+        else:
+            raise PyBallError(err_message)

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,10 @@
+class PyBallError(Exception):
+    pass
+
+
+class BadRequestError(PyBallError):
+    pass
+
+
+class InvalidIdError(PyBallError):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+pytest

--- a/test/test_game_type.py
+++ b/test/test_game_type.py
@@ -1,0 +1,15 @@
+import pytest
+from PyBall import PyBall
+from models.game_types import GameType
+
+from exceptions import *
+
+@pytest.fixture(scope='module')
+def test_game_type():
+    pyball = PyBall()
+    return pyball.get_game_types()
+
+
+def test_get_game_types_returns_list_of_game_types(test_game_type):
+    assert isinstance(test_game_type, list)
+    assert isinstance(test_game_type[0], GameType)

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -1,0 +1,27 @@
+import pytest
+from PyBall import PyBall
+from models.people import People
+
+from exceptions import *
+
+
+@pytest.fixture(scope='module')
+def test_player():
+    pyball = PyBall()
+    return pyball.get_player(446372)
+
+
+def test_get_player_endpoint_returns_player(test_player):
+    assert isinstance(test_player, People)
+
+
+def test_bad_player_id():
+    pyball = PyBall()
+    with pytest.raises(InvalidIdError):
+        pyball.get_player(-1)
+
+
+def test_player_id_not_a_num():
+    pyball = PyBall()
+    with pytest.raises(BadRequestError):
+        pyball.get_player("not_an_id")

--- a/test/test_venue.py
+++ b/test/test_venue.py
@@ -1,0 +1,27 @@
+import pytest
+from PyBall import PyBall
+from models.venue import Venue
+
+from exceptions import *
+
+
+@pytest.fixture(scope='module')
+def test_venue():
+    pyball = PyBall()
+    return pyball.get_venue(1)
+
+
+def test_get_venue_endpoint_returns_venue(test_venue):
+    assert isinstance(test_venue, Venue)
+
+
+def test_bad_venue_id():
+    pyball = PyBall()
+    with pytest.raises(InvalidIdError):
+        pyball.get_venue(-1)
+
+
+def test_venue_id_not_a_num():
+    pyball = PyBall()
+    with pytest.raises(BadRequestError):
+        pyball.get_venue("not_an_id")


### PR DESCRIPTION
This PR adds Travis CI functionality and a basic suite of integration tests to validate endpoints return the correct types or errors on requests.

Currently, the build status in the README points to my fork. Once you set up travis CI for this repo, I can update it to point here instead. It's really easy; just go to travis-ci.org and login with your github account.