### PR TITLE
Add springLeague attribute to Team

### DIFF
--- a/pyball/models/generic_team.py
+++ b/pyball/models/generic_team.py
@@ -26,9 +26,11 @@ class Team:
     active: bool = None
     parentOrgId: int = None
     parentOrgName: str = None
+    springLeague: Union[League, Dict[str, Any]] = field(default_factory=dict)
 
     def __post_init__(self):
         self.venue = Venue(**self.venue)
         self.league = League(**self.league)
         self.division = Division(**self.division)
         self.sport = Sport(**self.sport)
+        self.springLeague = League(**self.springLeague)


### PR DESCRIPTION
`get_teams()` and its variations was raising an exception when the results passed in a springLeague to `Team.__init__()`.

I noticed that all tests pass on Travis, but that wasn't the case when I forked the repo. This commit makes them pass, so I'm assuming the API itself changed in the meantime.